### PR TITLE
Magento v.2.2.2 (mostly Temando_Shipping) compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "nord/module-shipfunk",
     "description": "Shipfunk shipping method for Magento 2",
     "require": {
-        "php": "~5.6.0|7.0.2|~7.0.6",
+        "php": "~5.6.0|7.0.2|~7.0.6|~7.1.0",
         "magento/module-sales": "~100.0|~101.0"
     },
     "type": "magento2-module",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -8,5 +8,8 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
     <module name="Nord_Shipfunk" setup_version="2.0.0.0">
+        <sequence>
+            <module name="Temando_Shipping"/>
+        </sequence>
     </module>
 </config>


### PR DESCRIPTION
This should fix missing pickup info on admin sales order view page.
Basically Magento sneak peeked something called "Magento Shipping" in v.2.2.2 . And that is actually Temando_Shipping https://temando.com/en/connectors/magento-2-shipping-software. 
Now this module is almost last to load and it is overwriting order_info block, which we (and probably every other extension adding some custom info to order page) were using as place to inject our pickup info.

````xml
<referenceContainer name="order_tab_info">
        <block class="Temando\Shipping\Block\Adminhtml\Sales\Order\View\Info" name="order_info" template="Temando_Shipping::sales/order/view/info.phtml">
                <container name="extra_customer_info"/>
        </block>
 </referenceContainer>
````
So, basically, we just had to make sure that Shipfunk loads after Temando, and it's working. I've tested the whole process on demo site, which is now updated to Mage v.2.2.2, and it seams everything runs ok.

If you're pulling these changes to already running instance, you need to `bin/magento module:disable Nord_Shipfunk` and `bin/magento module:enable Nord_Shipfunk` for changes to take effect. The `app/etc/config.php` file should change to reflect Nord_Shipfunk loading after Temando_Shiping module.

Also, added support for PHP 7.1.* 


 